### PR TITLE
Fixed schema names to use title on definition

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -36,6 +36,9 @@ var schemaToHTML = function (name, schema, models, modelPropertyMacro) {
       modelName = schema.title || helpers.simpleRef(schema.$ref);
       model = models[modelName];
 
+      if (model != null && model.definition.title != null)  {
+        modelName = model.definition.title;
+      }
     } else if (_.isUndefined(name)) {
       modelName = schema.title || 'Inline Model ' + (++inlineModels);
       model = new Model(modelName, schema, models, modelPropertyMacro);


### PR DESCRIPTION
For some reason this fixes it though the other fix did change part of it, this also changes the schema relations under "response schema" properties.
