### PR TITLE
Removed wrapping body schema arrays with array text

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -383,11 +383,7 @@ Operation.prototype.getModelSignature = function (type, definitions) {
       return type.toString();
     }
   } else {
-    if (listType) {
-      return 'Array[' + type.getMockSignature() + ']';
-    } else {
-      return type.getMockSignature();
-    }
+    return type.getMockSignature();
   }
 };
 


### PR DESCRIPTION
In the body response it wraps schema arrays with Array[].
