### PR TITLE
Removed array heading on response schemas for schema arrays

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -191,8 +191,6 @@ var schemaToHTML = function (name, schema, models, modelPropertyMacro) {
       } else  {
         html = strongOpen + name +  strongClose;
       }
-    } else if (isArray) {
-      html = strongOpen + helpers.simpleRef(schema.items.$ref) + 's' +  strongClose;
     }
 
     if (name) {


### PR DESCRIPTION
I noticed on Auth0 if there is an array response in the schemas section it doesn't have the array heading. Do you like this?

https://auth0.com/docs/api/v2#!/Connections/get_connections
