### PR TITLE
Changed display of enum values for response schemas

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -285,7 +285,17 @@ var schemaToHTML = function (name, schema, models, modelPropertyMacro) {
               html += '<span class="propDesc">' + property.description;
 
               if (cProperty.enum) {
-                html += '<div class="propVals">[\'' + cProperty.enum.join('\' or ') + '\']</div>';
+                html += '<div class="propVals">Can be ';
+                _.forEach(cProperty.enum, function (value, key) {
+                  html += '<code>' + value + '</code>';
+                  if (key == cProperty.enum.length - 2) {
+                    html += ' or ';
+                  }
+                  else if (key < cProperty.enum.length - 1) {
+                    html += ', ';
+                  }
+                });
+                html += '</div>';
               }
 
               html += '</span>';


### PR DESCRIPTION
This changes the display of enum values to look more like Stripe, do you like this?

Where it says "Can be `Visa`, `American Express`.... or `Unknown`.
https://stripe.com/docs/api#card_object
