### PR TITLE
Fixed operation parameters to use schema title as parameter type

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -128,6 +128,17 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
       }
     }
 
+    if (typeof param.type === 'undefined') {
+      var schema = param.schema;
+      if (schema && schema.$ref) {
+        model = this.models[helpers.simpleRef(schema.$ref)];
+
+        if (model && model.definition.title) {
+          param.type = model.definition.title;
+        }
+      }
+    }
+
     param.signature = this.getModelSignature(innerType, this.models).toString();
     param.sampleJSON = this.getModelSampleJSON(innerType, this.models);
     param.responseClassSignature = param.signature;


### PR DESCRIPTION
I found another spot where the schema title wasn't being used which is on the operation where it shows the parameters it sets the type to the key and didn't use the schema's title property.
