### PR TITLE
Fixed showing enum description when schema description is empty

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -280,25 +280,27 @@ var schemaToHTML = function (name, schema, models, modelPropertyMacro) {
 
             html += '</span>';
 
+            html += '<span class="propDesc">';
+
             if (!_.isUndefined(property.description)) {
-              html += '<span class="propDesc">' + property.description;
-
-              if (cProperty.enum) {
-                html += '<div class="propVals">Can be ';
-                _.forEach(cProperty.enum, function (value, key) {
-                  html += '<code>' + value + '</code>';
-                  if (key === cProperty.enum.length - 2) {
-                    html += ' or ';
-                  }
-                  else if (key < cProperty.enum.length - 1) {
-                    html += ', ';
-                  }
-                });
-                html += '</div>';
-              }
-
-              html += '</span>';
+              html += property.description;
             }
+
+            if (cProperty.enum) {
+              html += '<div class="propVals">Can be ';
+              _.forEach(cProperty.enum, function (value, key) {
+                html += '<code>' + value + '</code>';
+                if (key === cProperty.enum.length - 2) {
+                  html += ' or ';
+                }
+                else if (key < cProperty.enum.length - 1) {
+                  html += ', ';
+                }
+              });
+              html += '</div>';
+            }
+
+            html += '</span>';
 
             return primitiveToOptionsHTML(cProperty, html);
           }).join('</div><div>');


### PR DESCRIPTION
I just noticed this a few days ago that if the description is not set and there are enum values they wouldn't  be shown, but now they will since they look like part of the description.
